### PR TITLE
O3-3073: change module api dependency in the omod to reference the parent rather than manually pointing to a version

### DIFF
--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -13,9 +13,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.openmrs.module</groupId>
-            <artifactId>stockmanagement-api</artifactId>
-            <version>1.4.0-SNAPSHOT</version>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-api</artifactId>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.openmrs.web</groupId>


### PR DESCRIPTION
https://openmrs.atlassian.net/browse/O3-3073