### PR TITLE
O3-4284 Ability to filter item transactions based on whether they are patient based or not

### DIFF
--- a/api/src/main/java/org/openmrs/module/stockmanagement/api/dao/StockManagementDao.java
+++ b/api/src/main/java/org/openmrs/module/stockmanagement/api/dao/StockManagementDao.java
@@ -3181,6 +3181,14 @@ public class StockManagementDao extends DaoBase {
             parameterList.putIfAbsent("odmx", filter.getTransactionDateMax());
         }
 
+        if (filter.getIsPatientTransaction() != null) {
+            if( filter.getIsPatientTransaction() == true) {
+                appendFilter(hqlFilter, "sit.patient.id is not null");
+            } else {
+                appendFilter(hqlFilter, "sit.patient.id is null");
+            }
+        }
+
         if (hqlFilter.length() > 0) {
             hqlQuery.append(" where ");
             hqlQuery.append(hqlFilter);
@@ -3191,6 +3199,7 @@ public class StockManagementDao extends DaoBase {
             result.setPageIndex(filter.getStartIndex());
             result.setPageSize(filter.getLimit());
         }
+        System.out.println("STOCK: executing query: " + hqlQuery);
         result.setData(executeQuery(StockItemTransactionDTO.class, hqlQuery, result, " order by sit.id desc", parameterList, parameterWithList));
 
         if (!result.getData().isEmpty()) {
@@ -3240,6 +3249,15 @@ public class StockManagementDao extends DaoBase {
                     if (party != null) {
                         stockItemTransactionDTO.setOperationDestinationPartyName(party.get(0).getName());
                     }
+                }
+                // stockItemTransactionDTO.setPatientId(1000);
+                Integer patientId = stockItemTransactionDTO.getPatientId();
+                System.out.println("Got patient id as: " + patientId);
+                if(patientId != null) {
+                    Patient patient = Context.getPatientService().getPatient(patientId);
+                    String patientUuid = patient.getUuid();
+                    System.out.println("Got patient uuid as: " + patientUuid);
+                    stockItemTransactionDTO.setPatientUuid(patientUuid);
                 }
             }
 

--- a/api/src/main/java/org/openmrs/module/stockmanagement/api/dto/StockItemTransactionDTO.java
+++ b/api/src/main/java/org/openmrs/module/stockmanagement/api/dto/StockItemTransactionDTO.java
@@ -19,6 +19,8 @@ public class StockItemTransactionDTO {
 	private String partyName;
 	
 	private Integer patientId;
+
+	private String patientUuid;
 	
 	private Integer orderId;
 	
@@ -266,5 +268,13 @@ public class StockItemTransactionDTO {
 	
 	public void setExpiration(Date expiration) {
 		this.expiration = expiration;
+	}
+
+	public String getPatientUuid() {
+		return patientUuid;
+	}
+
+	public void setPatientUuid(String patientUuid) {
+		this.patientUuid = patientUuid;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/stockmanagement/api/dto/StockItemTransactionSearchFilter.java
+++ b/api/src/main/java/org/openmrs/module/stockmanagement/api/dto/StockItemTransactionSearchFilter.java
@@ -21,6 +21,8 @@ public class StockItemTransactionSearchFilter {
 	Date transactionDateMax;
 	
 	public Integer afterLastStockOperationId;
+
+	private Boolean isPatientTransaction;
 	
 	public String getUuid() {
 		return uuid;
@@ -93,4 +95,14 @@ public class StockItemTransactionSearchFilter {
 	public void setAfterLastStockOperationId(Integer afterLastStockOperationId) {
 		this.afterLastStockOperationId = afterLastStockOperationId;
 	}
+
+	public Boolean getIsPatientTransaction() {
+		return isPatientTransaction;
+	}
+
+	public void setIsPatientTransaction(Boolean isPatientTransaction) {
+		this.isPatientTransaction = isPatientTransaction;
+	}
+
+	
 }

--- a/omod/src/main/java/org/openmrs/module/stockmanagement/web/resource/StockItemTransactionResource.java
+++ b/omod/src/main/java/org/openmrs/module/stockmanagement/web/resource/StockItemTransactionResource.java
@@ -93,6 +93,15 @@ public class StockItemTransactionResource extends ResourceBase<StockItemTransact
 			}
 			filter.setTransactionDateMax(date);
 		}
+
+		param = context.getParameter("isPatientTransaction");
+		if (StringUtils.isNotBlank(param)) {
+			if(param.trim().equalsIgnoreCase("true")) {
+				filter.setIsPatientTransaction(true);
+			} else if(param.trim().equalsIgnoreCase("false")) {
+				filter.setIsPatientTransaction(false);
+			}
+		}
 		
 		StockManagementService stockManagementService = getStockManagementService();
 		Result<StockItemTransactionDTO> result = stockManagementService.findStockItemTransactions(filter);
@@ -142,7 +151,8 @@ public class StockItemTransactionResource extends ResourceBase<StockItemTransact
 			description.addProperty("packagingUomFactor");
 			description.addProperty("operationSourcePartyName");
 			description.addProperty("operationDestinationPartyName");
-			
+			description.addProperty("patientId");
+			description.addProperty("patientUuid");
 		}
 		
 		if (rep instanceof DefaultRepresentation) {
@@ -185,7 +195,10 @@ public class StockItemTransactionResource extends ResourceBase<StockItemTransact
 			        .property("packagingUomName", new StringProperty())
 			        .property("packagingUomFactor", new DecimalProperty())
 			        .property("operationSourcePartyName", new StringProperty())
-			        .property("operationDestinationPartyName", new StringProperty());
+			        .property("operationDestinationPartyName", new StringProperty())
+					.property("patientId", new IntegerProperty())
+					.property("patientUuid", new StringProperty())
+					;
 		}
 		if (rep instanceof DefaultRepresentation) {}
 		


### PR DESCRIPTION
O3-4284 Ability to filter item transactions based on whether they are patient based or not
Example:
http://localhost:9677/openmrs/ws/rest/v1/stockmanagement/stockitemtransaction?v=default&limit=10&totalCount=true&stockItemUuid=599d2d8b-73a9-4031-b190-9fc333012dc3&isPatientTransaction=true

Where isPatientTransaction can be true or false or missing
if "true", return only patient dispense transactions
if "false", return all except patient dispense transactions
if missing return all transactions
